### PR TITLE
[geos]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# geos
+
+GEOS (Geometry Engine - Open Source) is a C++ port of the ​Java Topology Suite (JTS).
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.geos?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # geos
 
 GEOS (Geometry Engine - Open Source) is a C++ port of the ​Java Topology Suite (JTS).

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/geos-config'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/geos-config'
+command_relative_path: '/bin/geos-config'

--- a/controls/geos_exists.rb
+++ b/controls/geos_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm geos exists'
+
+plan_name = input('plan_name', value: 'geos')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+geos_relative_path = input('command_path', value: '/bin/geos-config')
+geos_installation_directory = command("hab pkg path #{plan_ident}")
+geos_full_path = geos_installation_directory.stdout.strip + "#{ geos_relative_path}"
+ 
+control 'core-plans-geos-exists' do
+  impact 1.0
+  title 'Ensure geos exists'
+  desc '
+  '
+   describe file(geos_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/geos_exists.rb
+++ b/controls/geos_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm geos exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'geos')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/geos-config')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-geos-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-geos-exists' do
   desc '
   Verify geos by ensuring /bin/geos-config exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/geos-config')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/geos_exists.rb
+++ b/controls/geos_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm geos exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'geos')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-geos_relative_path = input('command_path', value: '/bin/geos-config')
-geos_installation_directory = command("hab pkg path #{plan_ident}")
-geos_full_path = geos_installation_directory.stdout.strip + "#{ geos_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/geos-config')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-geos-exists' do
   impact 1.0
   title 'Ensure geos exists'
   desc '
-  '
-   describe file(geos_full_path) do
+  Verify geos by ensuring /bin/geos-config exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/geos_works.rb
+++ b/controls/geos_works.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm geos works as expected'
+
+plan_name = input('plan_name', value: 'geos')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+
+control 'core-plans-geos-works' do
+  impact 1.0
+  title 'Ensure geos works as expected'
+  desc '
+  '
+  geos_path = command("hab pkg path #{plan_ident}")
+  describe geos_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  geos_pkg_ident = ((geos_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("DEBUG=true; hab pkg exec #{ geos_pkg_ident} geos-config --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /3.7.1/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/geos_works.rb
+++ b/controls/geos_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm geos works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'geos')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-geos-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-geos-works' do
   it returns the expected version
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} geos-config --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/controls/geos_works.rb
+++ b/controls/geos_works.rb
@@ -1,24 +1,28 @@
 title 'Tests to confirm geos works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'geos')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-geos-works' do
   impact 1.0
   title 'Ensure geos works as expected'
   desc '
+  Verify geos by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  geos_path = command("hab pkg path #{plan_ident}")
-  describe geos_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  geos_pkg_ident = ((geos_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  describe command("DEBUG=true; hab pkg exec #{ geos_pkg_ident} geos-config --version") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} geos-config --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /3.7.1/ }
+    its('stdout') { should match /#{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: geos
+title: Habitat Core Plan geos
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan geos
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=geos
+pkg_origin=core
+pkg_version=3.7.1
+pkg_description="GEOS (Geometry Engine - Open Source) is a C++ port of the ​Java Topology Suite (JTS)."
+pkg_upstream_url=http://trac.osgeo.org/geos
+pkg_license=('LGPL')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_source=http://download.osgeo.org/geos/geos-${pkg_version}.tar.bz2
+pkg_shasum=0006c7b49eaed016b9c5c6f872417a7d7dc022e069ddd683335793d905a8228c
+pkg_build_deps=(
+  core/gcc
+  core/make
+  core/patchelf
+)
+pkg_deps=(
+  core/coreutils
+  core/glibc
+  core/gcc-libs
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+
+
+do_install() {
+  do_default_install
+
+  build_line "Patching ELF binaries:"
+  find "$pkg_prefix/lib" -type f -executable \
+    -exec sh -c 'file -i "$1" | grep -q "x-sharedlib; charset=binary"' _ {} \; \
+    -print \
+    -exec patchelf --set-rpath "${LD_RUN_PATH}" {} \;
+}

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,6 @@
+source "${BATS_TEST_DIRNAME}/../plan.sh"
+
+@test "Version matches" {
+  result="$(geos-config --version)"
+  [ "$result" = "${pkg_version}" ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+TESTDIR="$(dirname "${0}")"
+PLANDIR="$(dirname "${TESTDIR}")"
+SKIPBUILD=${SKIPBUILD:-0}
+
+hab pkg install core/bats --binlink
+
+source "${PLANDIR}/plan.sh"
+
+if [ "${SKIPBUILD}" -eq 0 ]; then
+  set -e
+  pushd "${PLANDIR}" > /dev/null
+  build
+  source results/last_build.env
+  hab pkg install "results/${pkg_artifact}" --binlink --force
+  popd > /dev/null
+  set +e
+fi
+
+bats "${TESTDIR}/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://07158c8ceb42a6a8230cfe42ab7ef7bc6f2074527155a97a075297b36b83107c --input-file /src/attributes.yml

Profile: Habitat Core Plan geos (geos)
Version: 0.1.0
Target:  docker://07158c8ceb42a6a8230cfe42ab7ef7bc6f2074527155a97a075297b36b83107c

  ✔  core-plans-geos-exists: Ensure geos exists
     ✔  File /hab/pkgs/core/geos/3.7.1/20200603161428/bin/geos-config is expected to exist
  ✔  core-plans-geos-works: Ensure geos works as expected
     ✔  Command: `hab pkg path core/geos` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/geos` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/geos/3.7.1/20200603161428 geos-config --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/geos/3.7.1/20200603161428 geos-config --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/geos/3.7.1/20200603161428 geos-config --version` stdout is expected to match /3.7.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/geos/3.7.1/20200603161428 geos-config --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[8][default:/src:0]# 
```